### PR TITLE
[Feature] Responsive circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,9 +576,11 @@
           const r1 = r * p2 + minr * p1;
           const r2 = r * p1 + minr * p2;
 
-          const x1 = (i * col) + r + margin - rdisp;
-          const x2 = (i * col) + r + margin + rdisp;
+          const x = (i * col) + r + margin;
+          const x1 = x - rdisp;
+          const x2 = x + rdisp;
           const y = j * col + r + margin;
+          
           svg.innerHTML += `<circle class="b" cx="${x2}" cy="${y}" r="${r2}" /> `;
           svg.innerHTML += `<circle class="a" cx="${x1}" cy="${y}" r="${r1}" /> `;
         }

--- a/index.html
+++ b/index.html
@@ -564,7 +564,7 @@
       const rprop = r / minr;
       const rdisp = (minr * (rprop - 1)) / 2
 
-      const height = nrows * (col) - r + margin * 2;
+      const height = nrows * col - r / 2 + margin * 1.5;
 
       svg.innerHTML = ``
       svg.style.height = height;

--- a/index.html
+++ b/index.html
@@ -566,25 +566,29 @@
 
       const height = nrows * col - r / 2 + margin * 1.5;
 
-      svg.innerHTML = ``
+      svg.innerHTML = '';
       svg.style.height = height;
+      let innerHTML = '';
 
-      for(let j = 0; j < nrows; j++) {
-        for(let i = 0; i < ncols; i++) {
-          const p1 = ((ncols - 1 - i) / ncols);
-          const p2 = (i / ncols);
-          const r1 = r * p2 + minr * p1;
-          const r2 = r * p1 + minr * p2;
+      for(let i = 0; i < ncols; i++) {
+        const p1 = ((ncols - 1 - i) / ncols);
+        const p2 = (i / ncols);
+        const r1 = r * p2 + minr * p1;
+        const r2 = r * p1 + minr * p2;
 
-          const x = (i * col) + r + margin;
-          const x1 = x - rdisp;
+        const x = (i * col) + r + margin;
+        const x1 = x - rdisp;
+
+        for(let j = 0; j < nrows; j++) {
           const x2 = x + rdisp;
           const y = j * col + r + margin;
-          
-          svg.innerHTML += `<circle class="b" cx="${x2}" cy="${y}" r="${r2}" /> `;
-          svg.innerHTML += `<circle class="a" cx="${x1}" cy="${y}" r="${r1}" /> `;
+
+          innerHTML += `<circle class="b" cx="${x2}" cy="${y}" r="${r2}" /> `;
+          innerHTML += `<circle class="a" cx="${x1}" cy="${y}" r="${r1}" /> `;
         }
       }
+
+      svg.innerHTML = innerHTML;
     }
 
     window.addEventListener('resize', draw);

--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@
 
   <script>
     const svg = document.querySelector("svg");
-    const roundToEven = (n) => 2 * Math.floor(n / 2) + 1;
+    const roundToOdd = (n) => 2 * Math.floor(n / 2) + 1;
 
     const margin = 40;
     const nrows = 4;
@@ -556,7 +556,7 @@
 
     const draw = () => {
       const width = window.innerWidth - (margin * 2);
-      const ncols = roundToEven(a * width + b);
+      const ncols = roundToOdd(a * width + b);
 
       const col = width / ncols;
       const r = (col / 2) * rProportion;

--- a/index.html
+++ b/index.html
@@ -536,23 +536,57 @@
 
   <script>
     const svg = document.querySelector("svg");
-    const ncols = 33, nrows = 4, o = 50;
-    const minr = 10;
-    const d = (window.outerWidth - 2*o)/(ncols-1);
-    const height = 1.5*o + (nrows-1)*d;
-    const r = d/140;
-    svg.innerHTML = `<rect x="0" y="0" width="${2*o+(ncols-1)*d}" height="${height}" fill="rgb(66,67,68)"/>`
-    svg.style.height = height;
-    for(let j=0;j<nrows;j++) {
-      for(let i=0;i<ncols;i++) {
-        const x = o + i*d;
-        const y = o + j*d;
-        const r1 = (i+minr)*r;
-        const r2 = ((ncols-1-i)+minr)*r;
-        svg.innerHTML += `<circle class="b" cx="${x}" cy="${y}" r="${r2}" /> `;
-        svg.innerHTML += `<circle class="a" cx="${x-9}" cy="${y}" r="${r1}" /> `;
+    const roundToEven = (n) => 2 * Math.floor(n / 2) + 1;
+
+    const margin = 40;
+    const nrows = 4;
+    const rToRmin = 0.25;
+    const rProportion = 0.7;
+
+    const colProportion = [
+      [500, 11],
+      [1600, 33],
+    ]
+
+    const sizeDelta = colProportion[1][0] - colProportion[0][0];
+    const colsDelta = colProportion[1][1] - colProportion[0][1];
+
+    const a = colsDelta / sizeDelta;
+    const b = colProportion[0][1] - (a * colProportion[0][0]);
+
+    const draw = () => {
+      const width = window.innerWidth - (margin * 2);
+      const ncols = roundToEven(a * width + b);
+
+      const col = width / ncols;
+      const r = (col / 2) * rProportion;
+      const minr = r * rToRmin;
+      const rprop = r / minr;
+      const rdisp = (minr * (rprop - 1)) / 2
+
+      const height = nrows * (col) - r + margin * 2;
+
+      svg.innerHTML = ``
+      svg.style.height = height;
+
+      for(let j = 0; j < nrows; j++) {
+        for(let i = 0; i < ncols; i++) {
+          const p1 = ((ncols - 1 - i) / ncols);
+          const p2 = (i / ncols);
+          const r1 = r * p2 + minr * p1;
+          const r2 = r * p1 + minr * p2;
+
+          const x1 = (i * col) + r + margin - rdisp;
+          const x2 = (i * col) + r + margin + rdisp;
+          const y = j * col + r + margin;
+          svg.innerHTML += `<circle class="b" cx="${x2}" cy="${y}" r="${r2}" /> `;
+          svg.innerHTML += `<circle class="a" cx="${x1}" cy="${y}" r="${r1}" /> `;
+        }
       }
     }
+
+    window.addEventListener('resize', draw);
+    draw();
   </script>
 </body>
 


### PR DESCRIPTION
The cute circle patterns in the header did not scale well for smaller devices, such as smartphones. To properly scale, the number of circles must adapt according to the resolution. In this PR, I propose the following progression:

![image](https://user-images.githubusercontent.com/562525/102698075-67923380-4200-11eb-87f8-36e19fc446b5.png)

The number of circles is rounded to the closest odd number so that there are two circles of the same size in the center. #aesthetics

The controlling variables for the linear progression and other aspects of the pattern are exposed at the beginning of the code.

Hopefully closes #12 !